### PR TITLE
fix: constrain sqlite version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ RUN mamba install --yes \
     'geopandas' \
     'matplotlib' \
     'mapclassify' \
-    'r-extrafont' && \
+    'r-extrafont' \ 
+    # FIX: Ensure that we get the split sqlite to avoid clobbering libsqlite.
+    #      This was added to fix a broken solve.
+    'sqlite>=3.39.0' && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
### Context
2i2c observed server start failures, and received support tickets relating to failed server starts.

### Investigation
The Dockerfile in this repository does not use lockfiles. This means that each time the image is built, Conda/Mamba are free to modify the set of package versions. A recent change in the package metadata has led to an _old_ version of the `sqlite` package being pulled in. This version vendors its own `libsqlite` version, which is then clobbered by other `libsqlite` dependency (with different versions). 

### Fix
To fix this, we need to provide the solver with information that we don't want different versions of `sqlite` and `libsqlite`. The easiest way to do this is just to set a minimum version of `sqlite`, whose newer feedstock is the source of both of these packages.